### PR TITLE
Hotfix: Null Object When No Info Stored In Metamask

### DIFF
--- a/authflow-snap/packages/snap/snap.manifest.json
+++ b/authflow-snap/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "5FWDZ47VRPf12CTCXPavf3XRPOO7ZwVFzlwlmaQyWZ8=",
+    "shasum": "xM7XLRh/Oqnl0LjIcsqn+BxcoCJiklNfemMwokzL6HI=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -29,5 +29,5 @@
     "endowment:page-home": {},
     "snap_manageState": {}
   },
-  "manifestVersion": "0.1.0"
+  "manifestVersion": "0.1"
 }

--- a/authflow-snap/packages/snap/src/snap-classes/SnapState.ts
+++ b/authflow-snap/packages/snap/src/snap-classes/SnapState.ts
@@ -208,10 +208,6 @@ export class SnapState {
       const credentials = await this.getCredentials();
       const newUUID = uuidv4();
 
-      if (!credentials) {
-        throw new Error('Failed to retrieve existing credentials.');
-      }
-
       const updatedCredentials = {
         ...credentials,
         [newUUID]: {


### PR DESCRIPTION
A null object is returned from the get operation if nothing has been stored in metamask encrypted storage, removing a check that inhibited proper operations. 